### PR TITLE
OPS-1059 Alter janus to work on serverless

### DIFF
--- a/janus.py
+++ b/janus.py
@@ -30,7 +30,11 @@ if __name__ == '__main__':
         exit(0)
 
     # Get variables from the metadata server
-    instance_name = get_metadata('instance', 'hostname')
+    try:
+        instance_name = get_metadata('instance', 'hostname')
+    except SystemExit:
+        print('Warning: Could not fetch metadata for instance hostname. Using default value "unknown".')
+        instance_name = 'unknown'
     project_id = get_metadata('project', 'project-id')
     project_and_instance_name = '{}.{}'.format(project_id, instance_name)[:64]
     token = get_metadata('instance', 'service-accounts/default/identity?format=standard&audience=gcp')


### PR DESCRIPTION
Instance_name isn't available on serverless which errors out.